### PR TITLE
Use a stable baseUrl for the three loadDataWithBaseURL calls in FunctionUtils

### DIFF
--- a/nga_phone_base_3.0/src/main/java/sp/phone/util/FunctionUtils.java
+++ b/nga_phone_base_3.0/src/main/java/sp/phone/util/FunctionUtils.java
@@ -108,7 +108,7 @@ public class FunctionUtils {
         contentTV.setWebViewClient(client);
 
         contentTV.setTag(row.getLou());
-        contentTV.loadDataWithBaseURL(null, row.getFormated_html_data(),
+        contentTV.loadDataWithBaseURL("https://nga.local/post", row.getFormated_html_data(),
                 "text/html", "utf-8", null);
     }
 
@@ -193,7 +193,7 @@ public class FunctionUtils {
         contentTV.setWebViewClient(client);
         contentTV
                 .loadDataWithBaseURL(
-                        null,
+                        "https://nga.local/signature",
                         FunctionUtils.signatureToHtmlText(row, showImage,
                                 ArticleUtil.showImageQuality(), fgColorStr,
                                 bgcolorStr, context), "text/html", "utf-8", null);
@@ -335,7 +335,7 @@ public class FunctionUtils {
         });
         contentTV.setWebViewClient(client);
         contentTV.loadDataWithBaseURL(
-                null,
+                "https://nga.local/vote",
                 FunctionUtils.VoteToHtmlText(row, showImage, ArticleUtil.showImageQuality(),
                         fgColorStr, bgcolorStr), "text/html", "utf-8", null);
         contentTV.requestLayout();


### PR DESCRIPTION
Closes #29.

`FunctionUtils.java` calls `WebView.loadDataWithBaseURL(null, html, ...)` in three places. The third call (the vote dialog) also attaches `addJavascriptInterface(new ProxyBridge(...), "ProxyBridge")` to the same WebView just above.

With `null` as the baseUrl, the rendered page has an `about:blank` origin. Any script that ends up in that page can reach `ProxyBridge` with no origin gate, since the bridge does not check callers and `about:blank` is not a useful origin to compare against.

### Change

Replace `null` with an app-scoped HTTPS URL on each call:

- post / inline content dialog: `"https://nga.local/post"`
- signature dialog: `"https://nga.local/signature"`
- vote dialog: `"https://nga.local/vote"`

The host is private and never resolved, but the WebView treats it as a stable origin. Each dialog now has a deterministic, controlled base URL.

### Provenance

The same fix already landed (or is open) on a sibling NGA fork at [Justwen/NGA-CLIENT-VER-OPEN-SOURCE#199](https://github.com/Justwen/NGA-CLIENT-VER-OPEN-SOURCE/issues/199) / [#200](https://github.com/Justwen/NGA-CLIENT-VER-OPEN-SOURCE/pull/200). `FunctionUtils.java` between the two forks is very close, so the same minimum-step fix applies here.

The signature / vote / post dialogs continue to render normally, since each renders data the app generates and none depends on a `null` base URL.