### PR TITLE
feat: 添加NGA图片域名选项

### DIFF
--- a/lib_common/src/main/java/gov/anzong/androidnga/common/PreferenceKey.java
+++ b/lib_common/src/main/java/gov/anzong/androidnga/common/PreferenceKey.java
@@ -72,6 +72,8 @@ public class PreferenceKey {
 
     public static final String KEY_NGA_DOMAIN = "nga_domain";
 
+    public static final String KEY_NGA_IMAGE_DOMAIN = "nga_image_domain";
+
     public static final String KEY_SEARCH_HISTORY_TOPIC = "search_history_topic";
 
     public static final String KEY_SEARCH_HISTORY_BOARD = "search_history_board";

--- a/lib_core/src/main/java/gov/anzong/androidnga/core/corebuild/HtmlAttachmentBuilder.java
+++ b/lib_core/src/main/java/gov/anzong/androidnga/core/corebuild/HtmlAttachmentBuilder.java
@@ -13,7 +13,7 @@ public class HtmlAttachmentBuilder implements IHtmlBuild {
 
     private static StringBuilder buildAudioAttachment(StringBuilder ret, AttachmentData attachment) {
         String url = attachment.getAttachUrl();
-        ret.append("<tr><td><a href='http://")
+        ret.append("<tr><td><a href='")
                 .append(attachment.getAttachmentHost())
                 .append("/attachments/")
                 .append(url)
@@ -25,7 +25,7 @@ public class HtmlAttachmentBuilder implements IHtmlBuild {
 
     private static StringBuilder buildVideoAttachment(StringBuilder ret, AttachmentData attachment) {
         String url = attachment.getAttachUrl();
-        ret.append("<tr><td><a href='http://")
+        ret.append("<tr><td><a href='")
                 .append(attachment.getAttachmentHost())
                 .append("/attachments/")
                 .append(url)
@@ -37,7 +37,7 @@ public class HtmlAttachmentBuilder implements IHtmlBuild {
 
     private static StringBuilder buildImageAttachment(StringBuilder ret, AttachmentData attachment, int index, List<String> imageUrls) {
 
-        String attachUrl = "http://" + attachment.getAttachmentHost() + "/attachments/" + attachment.getAttachUrl();
+        String attachUrl = attachment.getAttachmentHost() + "/attachments/" + attachment.getAttachUrl();
         String attachUrlThumb = attachUrl;
         String indexStr = String.valueOf(index);
         if ("1".equals(attachment.getThumb())) {

--- a/lib_core/src/main/java/gov/anzong/androidnga/core/data/HtmlData.java
+++ b/lib_core/src/main/java/gov/anzong/androidnga/core/data/HtmlData.java
@@ -28,6 +28,8 @@ public class HtmlData implements Cloneable {
 
     private String mNGAHost;
 
+    private String mNGAImageDomain;
+
     private List<CommentData> mCommentList;
 
     private List<AttachmentData> mAttachmentList;
@@ -143,6 +145,14 @@ public class HtmlData implements Cloneable {
 
     public void setNGAHost(String NGAHost) {
         mNGAHost = NGAHost;
+    }
+
+    public String getNGAImageDomain() {
+        return mNGAImageDomain;
+    }
+
+    public void setNGAImageDomain(String NGAImageDomain) {
+        mNGAImageDomain = NGAImageDomain;
     }
 
     public static HtmlData create(String rawData, String host) {

--- a/lib_core/src/main/java/gov/anzong/androidnga/core/decode/ForumDecoder.java
+++ b/lib_core/src/main/java/gov/anzong/androidnga/core/decode/ForumDecoder.java
@@ -36,6 +36,16 @@ public class ForumDecoder {
         return decode(rawData, htmlData, null);
     }
 
+    public static String decode(String rawData, String host, String imageDomain, List<String> urls) {
+        HtmlData htmlData = HtmlData.create(rawData, host);
+        htmlData.setNGAImageDomain(imageDomain);
+        return decode(rawData, htmlData, urls);
+    }
+
+    public static String decode(String rawData, String host, String imageDomain) {
+        return decode(rawData, host, imageDomain, null);
+    }
+
     public static String decodeBasic(String rawData) {
         return new ForumBasicDecoder().decode(rawData);
     }

--- a/lib_core/src/main/java/gov/anzong/androidnga/core/decode/ForumImageDecoder.java
+++ b/lib_core/src/main/java/gov/anzong/androidnga/core/decode/ForumImageDecoder.java
@@ -25,13 +25,13 @@ public class ForumImageDecoder implements IForumDecoder {
 
     private static final String REGEX_IMG_NO_HTTP = IGNORE_CASE_TAG + "\\[img]\\s*\\.(/[^\\[|\\]]+)\\s*\\[/img]";
 
-    private static final String REPLACE_IMG_NO_HTTP = "<a href='http://%1$s/attachments%2$s'><img src='http://%1$s/attachments%2$s'></a>";
+    private static final String REPLACE_IMG_NO_HTTP = "<a href='%1$s/attachments%2$s'><img src='%1$s/attachments%2$s'></a>";
 
     private static final String REGEX_IMG_WITH_HTTP = IGNORE_CASE_TAG + "\\[img]\\s*(http[^\\[|\\]]+)\\s*\\[/img]";
 
     private static final String REPLACE_IMG_WITH_HTTP = "<a href='$1'><img src='$1'></a>";
 
-    private static final String NGA_ATTACHMENT_HOST = "img.nga.178.com";
+    private static final String DEFAULT_IMAGE_DOMAIN = "http://img.nga.178.com";
 
     @Override
     public String decode(String content) {
@@ -40,7 +40,11 @@ public class ForumImageDecoder implements IForumDecoder {
 
     @Override
     public String decode(String content, HtmlData htmlData) {
-        String replace = String.format(REPLACE_IMG_NO_HTTP, NGA_ATTACHMENT_HOST, "$1");
+        String imageDomain = htmlData == null ? DEFAULT_IMAGE_DOMAIN : htmlData.getNGAImageDomain();
+        if (imageDomain == null) {
+            imageDomain = DEFAULT_IMAGE_DOMAIN;
+        }
+        String replace = String.format(REPLACE_IMG_NO_HTTP, imageDomain, "$1");
         content = StringUtils.replaceAll(content, REGEX_IMG_NO_HTTP, replace);
         content = StringUtils.replaceAll(content, REGEX_IMG_WITH_HTTP, REPLACE_IMG_WITH_HTTP);
         content = StringUtils.replaceAll(content, "(http\\S+).gif.(thumb_s|medium|thumb|thumb_ss).jpg", "$1.gif");

--- a/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/Utils.java
+++ b/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/Utils.java
@@ -24,6 +24,14 @@ public class Utils {
         return DOMAIN;
     }
 
+    public static String getNGAImageDomain() {
+        return ForumUtils.getAvailableImageDomain();
+    }
+
+    public static String getNGAImageDomainNoHttp() {
+        return ForumUtils.getAvailableImageDomainNoHttp();
+    }
+
     /**
      * 保存图片成功后，更新系统图库
      *

--- a/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/activity/ProfileActivity.java
+++ b/nga_phone_base_3.0/src/main/java/gov/anzong/androidnga/activity/ProfileActivity.java
@@ -32,7 +32,6 @@ import gov.anzong.androidnga.Utils;
 import gov.anzong.androidnga.arouter.ARouterConstants;
 import gov.anzong.androidnga.base.util.DeviceUtils;
 import gov.anzong.androidnga.base.util.ToastUtils;
-import gov.anzong.androidnga.core.data.HtmlData;
 import gov.anzong.androidnga.core.decode.ForumDecoder;
 import gov.anzong.androidnga.http.OnHttpCallBack;
 import sp.phone.common.NoteManangerImpl;
@@ -557,7 +556,7 @@ public class ProfileActivity extends BaseActivity implements OnHttpCallBack<Prof
     }
 
     public String signatureToHtmlText(final ProfileData ret, final String fgColorStr, final String bgcolorStr) {
-        String ngaHtml = ForumDecoder.decode(ret.getSign(), HtmlData.create(ret.getSign(), Utils.getNGAHost()));
+        String ngaHtml = ForumDecoder.decode(ret.getSign(), Utils.getNGAHost(), Utils.getNGAImageDomain());
 
         ngaHtml = "<HTML> <HEAD><META   http-equiv=Content-Type   content= \"text/html;   charset=utf-8 \">"
                 + "<body bgcolor= '#"

--- a/nga_phone_base_3.0/src/main/java/sp/phone/mvp/model/convert/ArticleConvertFactory.java
+++ b/nga_phone_base_3.0/src/main/java/sp/phone/mvp/model/convert/ArticleConvertFactory.java
@@ -27,7 +27,6 @@ import sp.phone.http.bean.ThreadRowInfo;
 import sp.phone.mvp.model.entity.ThreadPageInfo;
 import sp.phone.theme.ThemeManager;
 import sp.phone.util.FunctionUtils;
-import sp.phone.util.HttpUtil;
 import sp.phone.util.NLog;
 import sp.phone.util.StringUtils;
 
@@ -164,13 +163,14 @@ public class ArticleConvertFactory {
         htmlData.setSubject(row.getSubject());
         htmlData.setShowImage(PhoneConfiguration.getInstance().isImageLoadEnabled());
         htmlData.setNGAHost(Utils.getNGAHost());
+        htmlData.setNGAImageDomain(Utils.getNGAImageDomain());
         if (row.getAttachs() != null) {
             List<AttachmentData> attachments = new ArrayList<>();
             for (Map.Entry<String, Attachment> entry : row.getAttachs().entrySet()) {
                 AttachmentData data = new AttachmentData();
                 data.setAttachUrl(entry.getValue().getAttachurl());
                 data.setThumb(entry.getValue().getThumb());
-                data.setAttachmentHost(HttpUtil.NGA_ATTACHMENT_HOST);
+                data.setAttachmentHost(Utils.getNGAImageDomain());
                 attachments.add(data);
             }
             htmlData.setAttachmentList(attachments);

--- a/nga_phone_base_3.0/src/main/java/sp/phone/util/ForumUtils.java
+++ b/nga_phone_base_3.0/src/main/java/sp/phone/util/ForumUtils.java
@@ -26,6 +26,20 @@ public class ForumUtils {
         return context.getResources().getStringArray(R.array.nga_domain_no_http)[index];
     }
 
+    public static String getAvailableImageDomain() {
+        Context context = ContextUtils.getContext();
+        SharedPreferences sp = context.getSharedPreferences(PreferenceKey.PERFERENCE, Context.MODE_PRIVATE);
+        int index = Integer.parseInt(sp.getString(PreferenceKey.KEY_NGA_IMAGE_DOMAIN, "0"));
+        return context.getResources().getStringArray(R.array.nga_image_domain)[index];
+    }
+
+    public static String getAvailableImageDomainNoHttp() {
+        Context context = ContextUtils.getContext();
+        SharedPreferences sp = context.getSharedPreferences(PreferenceKey.PERFERENCE, Context.MODE_PRIVATE);
+        int index = Integer.parseInt(sp.getString(PreferenceKey.KEY_NGA_IMAGE_DOMAIN, "0"));
+        return context.getResources().getStringArray(R.array.nga_image_domain_no_http)[index];
+    }
+
     /**
      * @param statusCode
      * @return 返回子板块是否被订阅

--- a/nga_phone_base_3.0/src/main/java/sp/phone/util/FunctionUtils.java
+++ b/nga_phone_base_3.0/src/main/java/sp/phone/util/FunctionUtils.java
@@ -40,7 +40,6 @@ import gov.anzong.androidnga.BuildConfig;
 import gov.anzong.androidnga.R;
 import gov.anzong.androidnga.Utils;
 import gov.anzong.androidnga.base.util.ToastUtils;
-import gov.anzong.androidnga.core.data.HtmlData;
 import gov.anzong.androidnga.core.decode.ForumDecoder;
 import sp.phone.common.PhoneConfiguration;
 import sp.phone.common.UserManagerImpl;
@@ -454,7 +453,7 @@ public class FunctionUtils {
                                              boolean showImage, int imageQuality, final String fgColorStr,
                                              final String bgcolorStr, Context context) {
         initStaticStrings(context);
-        String ngaHtml = ForumDecoder.decode(row.getSignature(), HtmlData.create(row.getSignature(), Utils.getNGAHost()));
+        String ngaHtml = ForumDecoder.decode(row.getSignature(), Utils.getNGAHost(), Utils.getNGAImageDomain());
         if (StringUtils.isEmpty(ngaHtml)) {
             ngaHtml = row.getAlterinfo();
         }

--- a/nga_phone_base_3.0/src/main/java/sp/phone/util/HtmlUtils.java
+++ b/nga_phone_base_3.0/src/main/java/sp/phone/util/HtmlUtils.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 import gov.anzong.androidnga.R;
 import gov.anzong.androidnga.Utils;
-import gov.anzong.androidnga.core.data.HtmlData;
 import gov.anzong.androidnga.core.decode.ForumDecoder;
 import sp.phone.common.PhoneConfiguration;
 import sp.phone.http.bean.Attachment;
@@ -70,7 +69,7 @@ public class HtmlUtils {
         }
 
         List<String> imageUrls = new ArrayList<>();
-        String ngaHtml = ForumDecoder.decode(row.getContent(), HtmlData.create(row.getContent(), Utils.getNGAHost()), imageUrls);
+        String ngaHtml = ForumDecoder.decode(row.getContent(), Utils.getNGAHost(), Utils.getNGAImageDomain(), imageUrls);
         if (row.get_isInBlackList()) {
             ngaHtml = "<HTML> <HEAD><META http-equiv=Content-Type content= \"text/html; charset=utf-8 \">"
                     + "<body "
@@ -174,7 +173,7 @@ public class HtmlUtils {
 
     private static StringBuilder buildImageAttachment(StringBuilder ret, Attachment attachment, int index, List<String> imageUrls) {
 
-        String attachUrl = "http://" + HttpUtil.NGA_ATTACHMENT_HOST + "/attachments/" + attachment.getAttachurl();
+        String attachUrl = Utils.getNGAImageDomain() + "/attachments/" + attachment.getAttachurl();
         String attachUrlThumb = attachUrl;
         String indexStr = String.valueOf(index);
         if ("1".equals(attachment.getThumb())) {
@@ -209,7 +208,7 @@ public class HtmlUtils {
             int end = content.indexOf("[/b]");
             String time = '(' + comment.getPostdate() + ')';
             content = content.substring(end + 4);
-            content =  ForumDecoder.decode(content, HtmlData.create(content, Utils.getNGAHost()));
+            content =  ForumDecoder.decode(content, Utils.getNGAHost(), Utils.getNGAImageDomain());
             ret.append(String.format("<tr><td width='10%%'> <img src='%s' align='absmiddle' style='max-width:32;' />  <span style='font-weight:bold'>%s %s</span>%s</td></tr>",
                     avatarUrl, author, time, content));
 

--- a/nga_phone_base_3.0/src/main/java/sp/phone/util/StringUtils.java
+++ b/nga_phone_base_3.0/src/main/java/sp/phone/util/StringUtils.java
@@ -427,11 +427,12 @@ public class StringUtils {
 
         // [img]./ddd.jpg[/img]
         // if(showImage){
+        String imageDomain = Utils.getNGAImageDomain();
         ret = ret.replaceAll(ignoreCaseTag
                         + "\\[img\\]\\s*\\.(/[^\\[|\\]]+)\\s*\\[/img\\]",
-                "<a href='http://" + HttpUtil.NGA_ATTACHMENT_HOST
-                        + "/attachments$1'><img src='http://"
-                        + HttpUtil.NGA_ATTACHMENT_HOST
+                "<a href='" + imageDomain
+                        + "/attachments$1'><img src='"
+                        + imageDomain
                         + "/attachments$1' style= 'max-width:100%' ></a>");
         ret = ret.replaceAll(ignoreCaseTag
                         + "\\[img\\]\\s*(http[^\\[|\\]]+)\\s*\\[/img\\]",
@@ -480,7 +481,7 @@ public class StringUtils {
                         + s1
                         + "' style= 'max-width:100%' >";
                 content = content.replace(s0, newImgBlock);
-                int t = s1.indexOf(HttpUtil.NGA_ATTACHMENT_HOST);
+                int t = s1.indexOf(Utils.getNGAImageDomainNoHttp());
                 if (t != -1 && imageUrls != null) {
                     imageUrls.add(s1);
                 }

--- a/nga_phone_base_3.0/src/main/res/values/arrays.xml
+++ b/nga_phone_base_3.0/src/main/res/values/arrays.xml
@@ -89,4 +89,19 @@
         <item>4</item>
     </string-array>
 
+    <string-array name="nga_image_domain">
+        <item>http://img.nga.178.com</item>
+        <item>https://img.nga.cn</item>
+    </string-array>
+
+    <string-array name="nga_image_domain_no_http">
+        <item>img.nga.178.com</item>
+        <item>img.nga.cn</item>
+    </string-array>
+
+    <string-array name="nga_image_domain_value">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+
 </resources>

--- a/nga_phone_base_3.0/src/main/res/values/strings.xml
+++ b/nga_phone_base_3.0/src/main/res/values/strings.xml
@@ -353,6 +353,7 @@
     <string name="setting_title_notes_list">备注列表</string>
     <string name="setting_title_filter_sub_board">过滤版主固定的渣帖子</string>
     <string name="setting_nga_domain">NGA域名</string>
+    <string name="setting_nga_image_domain">NGA图片域名</string>
     <string name="setting_avatar_network_title">载入头像</string>
     <string name="setting_avatar_network_summary">移动数据网络下载入头像</string>
     <string name="setting_image_network_title">载入帖子图片</string>

--- a/nga_phone_base_3.0/src/main/res/xml-v28/settings.xml
+++ b/nga_phone_base_3.0/src/main/res/xml-v28/settings.xml
@@ -11,6 +11,14 @@
             android:key="nga_domain"
             android:title="@string/setting_nga_domain" />
 
+        <ListSummaryPreference
+            android:defaultValue="0"
+            android:dialogTitle="@string/setting_nga_image_domain"
+            android:entries="@array/nga_image_domain"
+            android:entryValues="@array/nga_image_domain_value"
+            android:key="nga_image_domain"
+            android:title="@string/setting_nga_image_domain" />
+
         <PreferenceScreen
             android:fragment="sp.phone.ui.fragment.SettingsUserFragment"
             android:key="pref_user"

--- a/nga_phone_base_3.0/src/main/res/xml/settings.xml
+++ b/nga_phone_base_3.0/src/main/res/xml/settings.xml
@@ -11,6 +11,14 @@
             android:key="nga_domain"
             android:title="@string/setting_nga_domain" />
 
+        <ListSummaryPreference
+            android:defaultValue="0"
+            android:dialogTitle="@string/setting_nga_image_domain"
+            android:entries="@array/nga_image_domain"
+            android:entryValues="@array/nga_image_domain_value"
+            android:key="nga_image_domain"
+            android:title="@string/setting_nga_image_domain" />
+
         <PreferenceScreen
             android:fragment="sp.phone.ui.fragment.SettingsUserFragment"
             android:key="pref_user"


### PR DESCRIPTION
## 关联 Issue
Closes #31 

##  修复背景
如 #31 所述，默认图片域名 `img.nga.178.com` 在部分地区下存在访问不稳定问题，导致图片加载失败。

## 修复方案
该修改增加了图片域名选择：
1. 在`设置`-`通用设置`下，新增图片域名选择
2. 原有基础上增加备用域名 `img.nga.cn`。

## 测试验证
环境：江苏苏州，中国移动。
刷新5次，均加载成功。

设置位置
<img width="450" height="450" alt="Screenshot_20260811_214203" src="https://github.com/user-attachments/assets/bfb2061a-87b3-4627-8c1d-5a4f1a298b4c" />
设置选项
<img width="450" height="700" alt="Screenshot_20260811_214209" src="https://github.com/user-attachments/assets/16c09574-6dd1-4aa7-8e0c-ba22c0dac856" />
修复前
<img width="450" height="300" alt="Screenshot_20260811_191714" src="https://github.com/user-attachments/assets/a3caf405-9723-41ba-87b6-3934d6826f79" />
修复后
<img width="450" height="300" alt="Screenshot_20260811_213736" src="https://github.com/user-attachments/assets/e3262f24-c8c0-4b63-b788-e7cf403470ea" />

